### PR TITLE
Finish times and port priority fix

### DIFF
--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -41,6 +41,8 @@
 //! @warning this macro is undef'd at the end of this file
 #define MAKE_RGB(r, g, b) (((r) << 0x10) | ((g) << 0x08) | (b << 0x00))
 
+bool gFinished[8];
+f32 gFinishTime[8];
 s32 D_80165590;
 s32 D_80165594;
 s32 D_80165598;

--- a/src/code_80057C60.h
+++ b/src/code_80057C60.h
@@ -257,6 +257,8 @@ void func_8006E940(Player*, s8, s8);
 void func_80075CA8(void);
 void func_80085214();
 
+extern bool gFinished[];
+extern f32 gFinishTime[];
 extern s16 D_800E4730[];
 extern u8** D_800E4770[];
 extern u8** D_800E47A0[];

--- a/src/cpu_vehicles_camera_path.c
+++ b/src/cpu_vehicles_camera_path.c
@@ -706,16 +706,17 @@ void detect_wrong_player_direction(s32 playerId, Player* player) {
     gPreviousLapProgressScore[playerId] = gNumPathPointsTraversed[playerId];
 }
 
-void set_places(void) {
-    s32 temp_s2;
-    f32 temp_f0;
-    s32 rankPlayer[8];
-    s32 a_really_cool_variable_name;
-    UNUSED s32 pad;
+void set_places(void){
+    s32 playerIdx;
+    s32 rankIdx;
+    s32 rankOld;
     s32 numPlayer;
-    s32 playerId;
-    s32 temp_a0;
-    s32 var_t1_3;
+    bool playerProcessed[8];
+    bool bestIsFinished;
+    f32 bestFinishTime;
+    f32 bestCourseCompletionPercent;
+    s32 bestPlayerIdx;
+    s32 playerIdByRank[8];
 
     switch (gModeSelection) {
         case BATTLE:
@@ -730,70 +731,61 @@ void set_places(void) {
             break;
     }
 
-    if (D_8016348C == 0) {
-        for (playerId = 0; playerId < numPlayer; playerId++) {
-            temp_a0 = gGPCurrentRacePlayerIdByRank[playerId];
-            rankPlayer[playerId] = temp_a0;
-            gCourseCompletionPercentByRank[playerId] = gCourseCompletionPercentByPlayerId[temp_a0];
-        }
-    } else {
-        for (playerId = 0; playerId < numPlayer; playerId++) {
-            temp_a0 = gGPCurrentRacePlayerIdByRank[playerId];
-            rankPlayer[playerId] = temp_a0;
-            gCourseCompletionPercentByRank[playerId] = -gTimePlayerLastTouchedFinishLine[temp_a0];
-        }
+    for (playerIdx = 0; playerIdx < numPlayer; playerIdx++){
+        playerProcessed[playerIdx] = false;
+        gPreviousGPCurrentRaceRankByPlayerId[playerIdx] = gGPCurrentRaceRankByPlayerId[playerIdx];
+        playerIdByRank[gGPCurrentRaceRankByPlayerId[playerIdx]] = playerIdx;
     }
 
-    for (playerId = 0; playerId < numPlayer - 1; playerId++) {
-        if ((gPlayers[gGPCurrentRacePlayerIdByRank[playerId]].type & 0x800)) {
-            continue;
-        }
+    // finds best player, puts them in 1st. 
+    // Best remaining player in 2nd...
+    for (rankIdx = 0; rankIdx < numPlayer; rankIdx++){
+        bestIsFinished = false;
+        // deliberately absurd value so that any player is better than it
+        bestFinishTime = 1000000;
+        bestCourseCompletionPercent = -1000000;
+        bestPlayerIdx = -1;
 
-        for (var_t1_3 = playerId + 1; var_t1_3 < numPlayer; var_t1_3++) {
-            if (gCourseCompletionPercentByRank[playerId] < gCourseCompletionPercentByRank[var_t1_3]) {
-                if (!(gPlayers[gGPCurrentRacePlayerIdByRank[var_t1_3]].type & 0x800)) {
-                    temp_s2 = rankPlayer[playerId];
-                    rankPlayer[playerId] = rankPlayer[var_t1_3];
-                    rankPlayer[var_t1_3] = temp_s2;
-                    temp_f0 = gCourseCompletionPercentByRank[playerId];
-                    gCourseCompletionPercentByRank[playerId] = gCourseCompletionPercentByRank[var_t1_3];
-                    gCourseCompletionPercentByRank[var_t1_3] = temp_f0;
+        /* uses previous ranks as tie-breaker. Only really relevant when
+           racers are not finished as they use course indexes, which is not very precise. 
+           Finish times are floating point, so it's almost impossible to get a true tie
+           among finished players */
+        for (rankOld = 0; rankOld < numPlayer; rankOld++){
+            playerIdx = playerIdByRank[rankOld];
+            if (playerProcessed[playerIdx]){
+                continue;
+            }
+            if (bestIsFinished){
+                if (gFinished[playerIdx] && gFinishTime[playerIdx] < bestFinishTime){
+                    bestFinishTime = gFinishTime[playerIdx];
+                    bestPlayerIdx = playerIdx;
+                }
+            } else {
+                if (gFinished[playerIdx]){
+                    bestIsFinished = true;
+                    bestFinishTime = gFinishTime[playerIdx];
+                    bestPlayerIdx = playerIdx;
+                } else {
+                    if (gCourseCompletionPercentByPlayerId[playerIdx] > bestCourseCompletionPercent){
+                        bestCourseCompletionPercent = gCourseCompletionPercentByPlayerId[playerIdx];
+                        bestPlayerIdx = playerIdx;
+                    }
                 }
             }
         }
-    }
+        playerProcessed[bestPlayerIdx] = true;
 
-    for (playerId = 0; playerId < NUM_PLAYERS; playerId++) {
-        gPreviousGPCurrentRaceRankByPlayerId[playerId] = gGPCurrentRaceRankByPlayerId[playerId];
-    }
-
-    for (playerId = 0; playerId < numPlayer; playerId++) {
-        gGPCurrentRacePlayerIdByRank[playerId] = rankPlayer[playerId];
-        gGPCurrentRaceRankByPlayerId[rankPlayer[playerId]] = playerId;
-    }
-
-    for (playerId = 0; playerId < numPlayer; playerId++) {
-        a_really_cool_variable_name = D_80164378[playerId];
-        rankPlayer[playerId] = a_really_cool_variable_name;
-        gCourseCompletionPercentByRank[playerId] = gCourseCompletionPercentByPlayerId[a_really_cool_variable_name];
-    }
-
-    for (playerId = 0; playerId < numPlayer - 1; playerId++) {
-        for (var_t1_3 = playerId + 1; var_t1_3 < numPlayer; var_t1_3++) {
-            if (gCourseCompletionPercentByRank[playerId] < gCourseCompletionPercentByRank[var_t1_3]) {
-                temp_s2 = rankPlayer[playerId];
-                rankPlayer[playerId] = rankPlayer[var_t1_3];
-                rankPlayer[var_t1_3] = temp_s2;
-                temp_f0 = gCourseCompletionPercentByRank[playerId];
-                gCourseCompletionPercentByRank[playerId] = gCourseCompletionPercentByRank[var_t1_3];
-                gCourseCompletionPercentByRank[var_t1_3] = temp_f0;
-            }
+        gGPCurrentRaceRankByPlayerId[bestPlayerIdx] = rankIdx;
+        gGPCurrentRacePlayerIdByRank[rankIdx] = bestPlayerIdx;
+        D_80164378[rankIdx] = gGPCurrentRacePlayerIdByRank[rankIdx];
+        gGPCurrentRaceRankByPlayerIdDup[rankIdx] = bestPlayerIdx;
+        // I am 90% sure this is unnecessary because gCourseCompletionPercentByRank is always reset when it is called,
+        // but I'm keeping it out of abundence of caution to be consistent with the old version of set_places
+        if (D_8016348C == 0) {
+            gCourseCompletionPercentByRank[rankIdx] = gCourseCompletionPercentByPlayerId[bestPlayerIdx];
+        } else {
+            gCourseCompletionPercentByRank[rankIdx] = -gTimePlayerLastTouchedFinishLine[bestPlayerIdx];
         }
-    }
-
-    for (playerId = 0; playerId < numPlayer; playerId++) {
-        gGPCurrentRaceRankByPlayerIdDup[rankPlayer[playerId]] = playerId;
-        D_80164378[playerId] = rankPlayer[playerId];
     }
 }
 
@@ -1200,11 +1192,12 @@ void update_cpu_path_completion(s32 playerId, Player* player) {
 
 /**
  * Helps calculate time since player last touched finishline.
+ * Assumes constant z-speed and subtracts portion of frame where the finish line was already crossed
  **/
-f32 func_80009258(UNUSED s32 playerId, f32 arg1, f32 arg2) {
-    f32 temp_f2 = gPathStartZ - arg2;
-    f32 temp_f12 = arg1 - gPathStartZ;
-    return gCourseTimer - ((COURSE_TIMER_ITER_f * temp_f2) / (temp_f2 + temp_f12));
+f32 func_80009258(UNUSED s32 playerId, f32 previousPlayerZ, f32 playerZ) {
+    f32 z_change_after_cross = gPathStartZ - playerZ;
+    f32 z_change_before_cross = previousPlayerZ - gPathStartZ;
+    return gCourseTimer - ((COURSE_TIMER_ITER_f * z_change_after_cross) / (z_change_after_cross + z_change_before_cross));
 }
 
 void update_player_path_completion(s32 playerId, Player* player) {
@@ -1269,6 +1262,10 @@ void update_player_path_completion(s32 playerId, Player* player) {
         if ((var_v1 != 0) && (playerZ <= gPathStartZ)) {
             if (gPathStartZ < previousPlayerZ) {
                 gLapCountByPlayerId[playerId]++;
+                if ((gLapCountByPlayerId[playerId] == 3) && !gFinished[playerId]){
+                    gFinished[playerId] = true;
+                    gFinishTime[playerId] = func_80009258(playerId, previousPlayerZ, playerZ);
+                }
                 if ((gModeSelection == GRAND_PRIX) && (gLapCountByPlayerId[playerId] == 5)) {
                     if (gGPCurrentRaceRankByPlayerIdDup[playerId] == 7) {
                         // clang-format off
@@ -1411,6 +1408,7 @@ void update_player(s32 playerId) {
     UNUSED s32 pad3[10];
     TrackPathPoint* pathPoint;
     f32 onePointFive = 1.5f;
+    s8 numPlayer;
 
     player = &gPlayers[playerId];
     if ((s32) GET_COURSE_AIMaximumSeparation >= 0) {
@@ -1460,7 +1458,22 @@ void update_player(s32 playerId) {
                 player->unk_044 &= ~0x0001;
             }
             update_player_path_completion(playerId, player);
-            if ((gCurrentCourseId != COURSE_AWARD_CEREMONY) && ((D_80163240[playerId] == 1) || (playerId == 0))) {
+
+            switch (gModeSelection) {
+                case BATTLE:
+                default:
+                    return; // HEY! returns, not breaks
+                case GRAND_PRIX:
+                case TIME_TRIALS:
+                    numPlayer = NUM_PLAYERS;
+                    break;
+                case VERSUS:
+                    numPlayer = gPlayerCount;
+                    break;
+            }
+
+            // checks on last player to ensure all players positions have been updated
+            if ((gCurrentCourseId != COURSE_AWARD_CEREMONY) && (playerId == (numPlayer - 1))) {
                 set_places();
             }
             if (player->type & PLAYER_CPU) {
@@ -2088,6 +2101,9 @@ void init_players(void) {
         gLapCountByPlayerId[i] = -1;
         gCourseCompletionPercentByPlayerId[i] = 0.0f;
         gTimePlayerLastTouchedFinishLine[i] = 0.0f;
+        gFinished[i] = false;
+        // arbitrary large number to be longer than any vs race
+        gFinishTime[i] = 1000000.0f;
         if (gModeSelection == GRAND_PRIX) {
             if (1) {};
             if (1) {}; // Maybe some debug code?

--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -213,11 +213,12 @@ Unk_D_800E70A0 D_800E7300[] = {
     { 0x18, 0x23, 0x00, 0x00 }, { 0x5d, 0x23, 0x00, 0x00 }, { 0xa2, 0x23, 0x00, 0x00 }, { 0xe7, 0x23, 0x00, 0x00 },
 };
 
+// Versus menu coordinates
 Unk_D_800E70A0 D_800E7360[] = {
-    { 0x61, 0xa7, 0x00, 0x00 },
     { 0x61, 0xb6, 0x00, 0x00 },
     { 0x61, 0xc5, 0x00, 0x00 },
     { 0x61, 0xd4, 0x00, 0x00 },
+    { 0x61, 0xe3, 0x00, 0x00 },
 };
 
 Unk_D_800E70A0 D_800E7380[] = {
@@ -8397,12 +8398,12 @@ void func_800A638C(MenuItem* arg0) {
             text_rainbow_effect(arg0->state - 0xA, var_s1, TEXT_GREEN);
             if ((var_s1 == 0) && (gModeSelection == VERSUS) && ((gPlayerCount == 3) || (gPlayerCount == 4))) {
                 continueText = "CONTINUE TO ";
-                print_text_mode_1(0x00000069, 0xAE + (0xF * var_s1), continueText, 0, 0.8f, 0.8f);
+                print_text_mode_1(0x00000069, 0xAE + (0xF * var_s1) + 15, continueText, 0, 0.8f, 0.8f);
                 xOffset = (get_string_width(continueText) * 0.8f) + 1.0f;
-                print_text_mode_1((s32) (0x00000069 + xOffset), 0xAE + (0xF * var_s1), getNextCourseAbbrString(),
+                print_text_mode_1((s32) (0x00000069 + xOffset), 0xAE + (0xF * var_s1) + 15, getNextCourseAbbrString(),
                                   0, 0.8f, 0.8f);
             } else {
-                print_text_mode_1(0x00000069, 0xAE + (0xF * var_s1), gTextPauseButton[var_s1 + 1], 0, 0.8f,
+                print_text_mode_1(0x00000069, 0xAE + (0xF * var_s1) + 15, gTextPauseButton[var_s1 + 1], 0, 0.8f,
                                   0.8f);
             }
         }
@@ -8471,27 +8472,29 @@ void func_800A66A8(MenuItem* arg0, Unk_D_800E70A0* arg1) {
 void func_800A69C8(UNUSED MenuItem* arg0) {
     Unk_D_800E70A0* thing;
     UNUSED s32 stackPadding1;
-    s32 var_s0;
+    s32 playerId;
     char sp74[5];
     s32 var_v1;
     char* temp_s3;
     u8* var_s4;
+    s32 finishTimeCopy;
+    char finishTimeText[8];
 
-    for (var_s0 = 0; var_s0 < gPlayerCount; var_s0++) {
+    for (playerId = 0; playerId < gPlayerCount; playerId++) {
         var_v1 = 0;
-        thing = &D_800E7300[var_s0];
+        thing = &D_800E7300[playerId];
         switch (gModeSelection) { /* irregular */
             case VERSUS:
-                if (gGPCurrentRaceRankByPlayerId[var_s0] != 0) {
+                if (gGPCurrentRaceRankByPlayerId[playerId] != 0) {
                     var_v1 = 1;
                 }
-                var_s4 = &gNmiUnknown1[var_s0];
+                var_s4 = &gNmiUnknown1[playerId];
                 break;
             case BATTLE:
-                if (var_s0 != gPlayerWinningIndex) {
+                if (playerId != gPlayerWinningIndex) {
                     var_v1 = 1;
                 }
-                var_s4 = &gNmiUnknown4[var_s0];
+                var_s4 = &gNmiUnknown4[playerId];
                 break;
         }
         temp_s3 = gWinLoseText[var_v1];
@@ -8501,12 +8504,35 @@ void func_800A69C8(UNUSED MenuItem* arg0) {
             set_text_color((s32) gGlobalTimer % 3);
         }
         func_800A79F4(var_s4[0], sp74);
-        text_draw(thing->column + 0x10, thing->row + 0x75, sp74, 0, 1.0f, 1.0f);
-        print_text1_center_mode_2(D_800E7380[var_s0].column, D_800E7380[var_s0].row, temp_s3, 0, 0.65f, 1.0f);
+        text_draw(thing->column + 0x10, thing->row + 0x75 + 15, sp74, 0, 1.0f, 1.0f);
+        print_text1_center_mode_2(D_800E7380[playerId].column, D_800E7380[playerId].row, temp_s3, 0, 0.65f, 1.0f);
+
+        // show finish time if finished
+        if (gFinished[playerId]){
+            // winner gets flashing timer
+            if (var_v1 != 1){
+                set_text_color(gGlobalTimer % 3);
+            }
+            else{
+                set_text_color(TEXT_YELLOW);
+            }
+            finishTimeCopy = (s32) (1000 * gFinishTime[playerId]);
+
+            // 48 is the offset from digits to ASCII code string representations
+            finishTimeText[0] = func_8004F674(&finishTimeCopy, 60000) + 48;
+            finishTimeText[1] = 39; // '
+            finishTimeText[2] = func_8004F674(&finishTimeCopy, 10000) + 48;
+            finishTimeText[3] = func_8004F674(&finishTimeCopy, 1000) + 48;
+            finishTimeText[4] = 34; // "
+            finishTimeText[5] = func_8004F674(&finishTimeCopy, 100) + 48;
+            finishTimeText[6] = func_8004F674(&finishTimeCopy, 10) + 48;
+            finishTimeText[7] = finishTimeCopy + 48;
+            text_draw(thing->column, thing->row + 0x75 - 25, finishTimeText, 0, 0.7f, 0.7f);
+        }
     }
     set_text_color(TEXT_BLUE);
     // Not a hyphen, that is an EUC-JP character
-    text_draw(0x0000009E, D_800E7300[0].row + 0x6D, "ー", 0, 1.0f, 1.0f);
+    text_draw(0x0000009E, D_800E7300[0].row + 0x6D + 15, "ー", 0, 1.0f, 1.0f);
 }
 
         /*Iterates over all players and, based on the current mode selection, 
@@ -8579,12 +8605,14 @@ void func_800A6D94(s32 arg0, s32 arg1, u8* arg2) {
 
  draws race finish tallies for versus races
  additionally draws vs scores for tournament edition*/
-void func_800A6E94(s32 arg0, s32 arg1, u8* arg2) {
+void func_800A6E94(s32 playerCount, s32 playerId, u8* placeAry) {
     UNUSED s32 stackPadding0;
     u8* temp_v0;
     Unk_D_800E70A0* temp_s0;
     char sp40[3];
     s32 rank;
+    s32 finishTimeCopy;
+    char finishTimeText[8];
 
     // var for drawing scores
     s32 base_xPos_4p;
@@ -8601,7 +8629,7 @@ void func_800A6E94(s32 arg0, s32 arg1, u8* arg2) {
     char pointsBuf[5]; 
 
     // Everything about this variable is bizarre
-    s32 sp38 = -1;
+    s32 rankIdx = -1;
 
     // base x and y position for drawing scores
     // x-coord increment will be different for 3p and 4p vs
@@ -8617,7 +8645,7 @@ void func_800A6E94(s32 arg0, s32 arg1, u8* arg2) {
 
     // Only draw scores on the first player call to avoid overdraw
     // (func_800A6E94 is called once per player by func_800A6BEC/func_800A6CC0)
-    if (arg1 == 0) {
+    if (playerId == 0) {
         set_text_color(TEXT_YELLOW);
         while(i < gPlayerCountSelection1) {
             firsts  = tally[i * 3 + 0];
@@ -8646,33 +8674,56 @@ void func_800A6E94(s32 arg0, s32 arg1, u8* arg2) {
         }
     }
 
-    temp_s0 = &D_800E7300[((arg0 - 2) * 4) + arg1];
-    rank = gGPCurrentRaceRankByPlayerId[arg1];
-    if (rank == ++sp38) {
+    temp_s0 = &D_800E7300[((playerCount - 2) * 4) + playerId];
+    rank = gGPCurrentRaceRankByPlayerId[playerId];
+    if (rank == ++rankIdx) {
         set_text_color(gGlobalTimer % 3);
     } else {
         set_text_color(TEXT_YELLOW);
     }
-    text_draw(temp_s0->column + 4, temp_s0->row + 0x5A, "1 ｓ ー", 0, 0.8f, 0.8f);
-    temp_v0 = arg2 + (arg1 * 3);
+    text_draw(temp_s0->column + 4, temp_s0->row + 0x69, "1 ｓ ー", 0, 0.8f, 0.8f);
+    temp_v0 = placeAry + (playerId * 3);
     convert_number_to_ascii(temp_v0[0], sp40); // first place tally for each player
-    text_draw(temp_s0->column + 0x2D, temp_s0->row + 0x5A, sp40, 0, 0.8f, 0.8f);
-    if (rank == ++sp38) {
+    text_draw(temp_s0->column + 0x2D, temp_s0->row + 0x69, sp40, 0, 0.8f, 0.8f);
+    if (rank == ++rankIdx) {
         set_text_color(gGlobalTimer % 3);
     } else {
         set_text_color(TEXT_BLUE);
     }
-    text_draw(temp_s0->column + 4, temp_s0->row + 0x69, "2 ｎ ー", 0, 0.8f, 0.8f);
+    text_draw(temp_s0->column + 4, temp_s0->row + 0x78, "2 ｎ ー", 0, 0.8f, 0.8f);
     convert_number_to_ascii(temp_v0[1], sp40); // second place tally for each player
-    text_draw(temp_s0->column + 0x2D, temp_s0->row + 0x69, sp40, 0, 0.8f, 0.8f);
-    if (++sp38 == rank) {
+    text_draw(temp_s0->column + 0x2D, temp_s0->row + 0x78, sp40, 0, 0.8f, 0.8f);
+    if (++rankIdx == rank) {
         set_text_color(gGlobalTimer % 3);
     } else {
         set_text_color(TEXT_RED);
     }
-    text_draw(temp_s0->column + 4, temp_s0->row + 0x78, "3 ｒ ー", 0, 0.8f, 0.8f);
+    text_draw(temp_s0->column + 4, temp_s0->row + 0x87, "3 ｒ ー", 0, 0.8f, 0.8f);
     convert_number_to_ascii(temp_v0[2], sp40); // third place tally for each player
-    text_draw(temp_s0->column + 0x2D, temp_s0->row + 0x78, sp40, 0, 0.8f, 0.8f);
+    text_draw(temp_s0->column + 0x2D, temp_s0->row + 0x87, sp40, 0, 0.8f, 0.8f);
+
+    // show time if player has finished
+    if (gFinished[playerId]){
+        // flash timer for winner
+        if (rank == 0){
+            set_text_color(gGlobalTimer % 3);
+        }
+        else{
+            set_text_color(TEXT_YELLOW);
+        }
+        finishTimeCopy = (s32) (1000 * gFinishTime[playerId]);
+
+        // 48 is the offset from digits to ASCII code string representations
+        finishTimeText[0] = func_8004F674(&finishTimeCopy, 60000) + 48;
+        finishTimeText[1] = 39; // '
+        finishTimeText[2] = func_8004F674(&finishTimeCopy, 10000) + 48;
+        finishTimeText[3] = func_8004F674(&finishTimeCopy, 1000) + 48;
+        finishTimeText[4] = 34; // "
+        finishTimeText[5] = func_8004F674(&finishTimeCopy, 100) + 48;
+        finishTimeText[6] = func_8004F674(&finishTimeCopy, 10) + 48;
+        finishTimeText[7] = finishTimeCopy + 48;
+        text_draw(temp_s0->column + 4, temp_s0->row + 0x5A, finishTimeText, 0, 0.7f, 0.7f);
+    }
 }
 
 void func_800A70E8(MenuItem* arg0) {

--- a/src/racing/race_logic.c
+++ b/src/racing/race_logic.c
@@ -538,52 +538,45 @@ f32 func_8028EE8C(s32 arg0) {
 }
 
 // set finish state
-void func_8028EEF0(s32 i) {
+void add_cinematic_mode(s32 i) {
     gPlayers[i].type |= PLAYER_CINEMATIC_MODE;
 }
 
-// synchronizes lap counts and awards race tallies
 void func_8028EF28(void) {
     s16 currentPosition;
-    s32 i; // player index
+    s32 playerId;
+    s32 playerIdLast;
 
-    for (i = 0; i < NUM_PLAYERS; i++) {
-        Player* player = &gPlayers[i];
+    for (playerId = 0; playerId < NUM_PLAYERS; playerId++) {
+        Player* player = &gPlayers[playerId];
 
         // skip slots that don't have active player
-        if ((gPlayers[i].type & PLAYER_EXISTS) == 0) {
+        if ((player->type & PLAYER_EXISTS) == 0) {
             continue;
         }
 
-        // skip finished players (players in cinematic mode)
-        // added condition to prevent double finishes/Wonn from cheating
-        if ((gPlayers[i].type & PLAYER_CINEMATIC_MODE) != 0) {
-            continue;
-        }
-       
         // handles increasing and decreasing lap count
         // two diff var for tracking lap counts
-        if (gLapCountByPlayerId[i] < gPlayers[i].lapCount) {
-            gPlayers[i].lapCount--;
-        } else if (gLapCountByPlayerId[i] > gPlayers[i].lapCount) {
-            gPlayers[i].lapCount++;
+        if (gLapCountByPlayerId[playerId] < player->lapCount) {
+            player->lapCount--;
+        } else if (gLapCountByPlayerId[playerId] > player->lapCount) {
+            player->lapCount++;
 
             // if slot has an active player 
-            if ((gPlayers[i].type & PLAYER_HUMAN) != 0) {
-                // if player i finishes (crosses into lap 4)
-                if (gPlayers[i].lapCount == 3) { // 3 = lap 4
-                    func_8028EEF0(i); // finish sequence
+            if ((player->type & PLAYER_HUMAN) != 0) {
+                // if player finishes (3 = starting 4th lap = finished)
+                if (player->lapCount == 3) {
+                    add_cinematic_mode(playerId);
 
-                    currentPosition = gPlayers[i].currentRank; // store rank as currentPosition 
-                    gPlayers[i].type |= PLAYER_CPU;            // cpu take over finishing player
+                    currentPosition = player->currentRank; // store rank as currentPosition 
+                    player->type |= PLAYER_CPU;            // cpu take over finishing player
 
-                    // sets flag after any player finishes lap 4
-                    if (currentPosition < 4) { 
+                    if (currentPosition < 4) {
                         D_80150120 = 1;
                     }
 
                     // ?
-                    func_800CA118((u8) i);
+                    func_800CA118((u8) playerId);
                     if ((D_802BA032 & PLAYER_EXISTS) == 0) {
                         D_802BA032 |= PLAYER_EXISTS;
                     }
@@ -591,8 +584,15 @@ void func_8028EF28(void) {
                     if (gModeSelection == GRAND_PRIX && gPlayerCountSelection1 == 2 && D_802BA048 == 0) {
                         D_802BA048 = 1;
                     }
-                    if ((gPlayers[i].type & PLAYER_INVISIBLE_OR_BOMB) == 0) {
-                        D_800DC510 = 4;
+                    if ((player->type & PLAYER_INVISIBLE_OR_BOMB) == 0) {
+                        // Inner if required for precise finish times.
+                        // Otherwise, higher port numbers can reset the state after a lower
+                        // port number finished 2nd to last, concluding the race
+                        if (D_800DC510 <= 4){
+                            // 4 means somebody has finished the race (or something similar)  
+                            // 5 means 2nd to last has finished, concluding the race
+                            D_800DC510 = 4;
+                        }
                     }
                     if (gModeSelection == TIME_TRIALS) {
                         func_80005AE8(player);
@@ -601,76 +601,79 @@ void func_8028EF28(void) {
                     if (gModeSelection == VERSUS) {
                         gDemoTimer = 180;
                         if (currentPosition == 0) { // winning player
-                            gPlayerWinningIndex = i;
+                            gPlayerWinningIndex = playerId;
                         }
                         switch (gPlayerCountSelection1) {
-                            // 2p vs
                             case 2:
-                                // currentPosition = position of player i when crossing finish line
-                                // 1st is 0, 2nd is 1, 3rd is 2, 4th is 3
+                                // currentPosition = position of player when crossing finish line (0 indexed)
+                                // 0 is 1st, 1 is 2nd, 2 is 3rd, 3 is 4th
                                 if (currentPosition == 0 ) { // when first finishes
-                                    *(gNmiUnknown1 + i) += 1; // add tally
-                                }
-                                if (*(gNmiUnknown1 + i) > 99) { // 99 tally limit?
-                                    *(gNmiUnknown1 + i) = 99;
-                                }
-                                D_800DC510 = 5;
-                                i = gPlayerPositionLUT[1];                 // get 2nd place player position
-                                gPlayers[i].triggers |= SPINOUT_TRIGGER;   // spin out 2nd place player
-                                gPlayers[i].type |= PLAYER_CPU;            // cpu control 2nd place player
-                                func_800CA118((u8) i);                     // call animation sequence, pass in losing player idx as parameter?
-                                break;
-                            // 3p
-                            case 3:
-                                if (currentPosition < 3 ) { // when any player finishes (all players get tallies)
-                                    *(gNmiUnknown2 + i * 3 + currentPosition) += 1;
-                                }
-                                if (*(gNmiUnknown2 + i * 3 + currentPosition) > 99) {
-                                    *(gNmiUnknown2 + i * 3 + currentPosition) = 99;
-                                }
-                                if (currentPosition == 1 ) { // when 2nd finishes
-                                    D_800DC510 = 5;
-                                    i = gPlayerPositionLUT[2]; // get 3rd place player position
-                                    *(gNmiUnknown2 + i * 3 + 2) += 1;
-                                    if (*(gNmiUnknown2 + i * 3 + 2) > 99) {
-                                        *(gNmiUnknown2 + i * 3 + 2) = 99;
+                                    *(gNmiUnknown1 + playerId) += 1; // add tally
+                                    if (*(gNmiUnknown1 + playerId) > 99) {
+                                        *(gNmiUnknown1 + playerId) = 99;
                                     }
-                                    gPlayers[i].triggers |= SPINOUT_TRIGGER; // spin out 3rd place player
-                                    gPlayers[i].type |= PLAYER_CPU;          // cpu control 3rd place
-                                    func_800CA118((u8) i);                   // call animation sequence, pass in losing player idx as parameter?
+                                    D_800DC510 = 5;
+                                    playerIdLast = gPlayerPositionLUT[1];                 // get 2nd place player position
+                                    gPlayers[playerIdLast].triggers |= SPINOUT_TRIGGER;   // spin out 2nd place player
+                                    gPlayers[playerIdLast].type |= PLAYER_CPU;            // cpu control 2nd place player
+                                    func_800CA118((u8) playerIdLast);                     // call animation sequence, pass in losing player idx as parameter?
                                 }
                                 break;
-                            // 4p
+                            case 3:
+                                if (currentPosition < 2) {
+                                    *(gNmiUnknown2 + playerId * 3 + currentPosition) += 1;
+                                
+                                    if (*(gNmiUnknown2 + playerId * 3 + currentPosition) > 99) {
+                                        *(gNmiUnknown2 + playerId * 3 + currentPosition) = 99;
+                                    }
+                                    /* Because the last player may not finish, their score must be updated when the 2nd
+                                       to last racer finishes. */
+                                    if (currentPosition == 1) {
+                                        D_800DC510 = 5; // triggers results screen
+
+                                        playerIdLast = gPlayerPositionLUT[2];
+                                        // update 3rd place (last) tally here because they may not cross finish line
+                                        *(gNmiUnknown2 + playerIdLast * 3 + 2) += 1;
+                                        if (*(gNmiUnknown2 + playerIdLast * 3 + 2) > 99) {
+                                            *(gNmiUnknown2 + playerIdLast * 3 + 2) = 99;
+                                        }
+                                        gPlayers[playerIdLast].triggers |= SPINOUT_TRIGGER; // spin out 3rd place player
+                                        gPlayers[playerIdLast].type |= PLAYER_CPU;          // cpu control 3rd place
+                                        func_800CA118((u8) playerIdLast);                   // call animation sequence, pass in losing player idx as parameter?
+                                    }
+                                }
+                                break;
                             case 4:
                                 // 4th place gets no tally
-                                if (currentPosition < 3 ) { // only when 1st, 2nd, 3rd finish
-                                    *(gNmiUnknown3 + i * 3 + currentPosition) += 1;
+                                if (currentPosition < 3) {
+                                    *(gNmiUnknown3 + playerId * 3 + currentPosition) += 1;
+                                    if (*(gNmiUnknown3 + playerId * 3 + currentPosition) > 99) {
+                                        *(gNmiUnknown3 + playerId * 3 + currentPosition) = 99;
+                                    }
                                 }
-                                if (*(gNmiUnknown3 + i * 3 + currentPosition) > 99) {
-                                    *(gNmiUnknown3 + i * 3 + currentPosition) = 99;
-                                }
-                                if (currentPosition == 2 ) { // when 3rd finishes
+                                // if 3rd has finished, race is over
+                                if (currentPosition == 2) {
                                     D_800DC510 = 5;
-                                    i = gPlayerPositionLUT[3];               // get 4th place player position
-                                    gPlayers[i].triggers |= SPINOUT_TRIGGER; // spin out 4th place
-                                    gPlayers[i].type |= PLAYER_CPU;          // cpu control 4th place
-                                    func_800CA118((u8) i);                   // call animation sequence, pass in losing player idx as parameter?
+                                    playerIdLast = gPlayerPositionLUT[3];               // get 4th place player position
+                                    gPlayers[playerIdLast].triggers |= SPINOUT_TRIGGER; // spin out 4th place
+                                    gPlayers[playerIdLast].type |= PLAYER_CPU;          // cpu control 4th place
+                                    func_800CA118((u8) playerIdLast);                   // call animation sequence, pass in losing player idx as parameter?
                                 }
                                 break;
                         }
                     }
 
-                } else if (gPlayers[i].lapCount == 2) {
-                    if ((gPlayers[i].type & 0x100) != 0) {
+                } else if (player->lapCount == 2) {
+                    if ((player->type & 0x100) != 0) {
                         return;
                     }
                     if ((D_802BA032 & 0x4000) == 0) {
                         D_802BA032 |= 0x4000;
-                        func_800CA49C((u8) i);
+                        func_800CA49C((u8) playerId);
                     }
                 }
-            } else if (gPlayers[i].lapCount == 3) {
-                func_8028EEF0(i);
+            } else if (player->lapCount == 3) {
+                add_cinematic_mode(playerId);
                 if (gModeSelection == TIME_TRIALS) {
                     func_80005AE8(player);
                 }
@@ -692,8 +695,7 @@ void update_race_position_data(void) {
     s16 position;
 
     for (i = 0; i < NUM_PLAYERS; i++) {
-        if (((gPlayers[i].type & PLAYER_EXISTS) != 0) && ((gPlayers[i].type & PLAYER_CINEMATIC_MODE) == 0) &&
-            ((gPlayers[i].type & PLAYER_INVISIBLE_OR_BOMB) == 0)) {
+        if (((gPlayers[i].type & PLAYER_EXISTS) != 0)) {
             position = gGPCurrentRaceRankByPlayerId[i];
             gPlayers[i].currentRank = position;
             gPlayerPositionLUT[position] = i;

--- a/src/racing/race_logic.h
+++ b/src/racing/race_logic.h
@@ -16,7 +16,7 @@ void func_8028EC38(s32);
 void play_music_for_current_track(s32);
 void start_race(void);
 f32 func_8028EE8C(s32);
-void func_8028EEF0(s32);
+void add_cinematic_mode(s32);
 void func_8028EF28(void);
 void func_8028F3E8(void);
 void update_race_position_data(void);


### PR DESCRIPTION
Fixes port priority in versus and shows finish times on versus results screen

Previously, if two players finished on the same physics frame in versus, the player with the lower port number would be awarded the better place. Now, the game checks the finish time of each player (to floating point precision) to determine the winner. Additionally, finish times are shown on the results screen (displayed to the thousandth) so that players can verify the accuracy of the awarded finish order (and see just how close extremely tight races were)


**Technical Details:**
* Creates a specific flag for whether a player is finished `gFinished`  
* Stores a player's finish time when they finish (`gFinishTime`) instead of just using the last time they touched the finish (`gTimePlayerLastTouchedFinishLine`) which can change if they touch the finish again
* Complete rewrite of `set_places` in `src\cpu_vehicles_camera_path.c` in a more robust way
  * Now calls `set_places` after the last player is processed, instead of on player 1, so all players have been updated for an equal number of frames  
* Add finish times to versus results screens through `src\menu_items.c`, adjusting positioning of other menu entries as necessary
* Small, but important changes to `func_8028EF28` in `src\racing\race_logic.c` to make point calculations more robust when racers finish on the same frame (especially in orders not previously possible)

**Tested:**
* Confirmed expected behavior with sub-frame victories in 2p, 3p, 4p. No observed change in behavior in GP.
* Recommendations for testing:
  * set `gLapCountByPlayerId[i] = 2;` in `init_players` (`cpu_vehicles_camera_path.c`) to start racers on 3rd lap.
  * Use save states to retest slightly different scenarios  
  * Bind A on multiple controllers to the same input, in order to accelerate all vehicles identically when desired